### PR TITLE
fix: remove unnecessary await

### DIFF
--- a/pages/api/revalidate.ts
+++ b/pages/api/revalidate.ts
@@ -56,15 +56,15 @@ async function queryStaleRoutes(
     case memberSchema.name:
       return getAllLocaleRoutes('/about')
     case jobSchema.name:
-      return await queryStaleJobRoutes(client, body._id)
+      return queryStaleJobRoutes(client, body._id)
     case portfolioSchema.name:
-      return await queryStalePortfolioRoutes(client, body._id)
+      return queryStalePortfolioRoutes(client, body._id)
     default:
       throw new TypeError(`Unknown type: ${body._type}`)
   }
 }
 
-async function queryStaleJobRoutes(client: SanityClient, id: string) {
+function queryStaleJobRoutes(client: SanityClient, id: string) {
   return [
     ...getAllLocaleRoutes('/careers'),
     ...getAllLocaleRoutes(`/careers/${id.replace('__i18n_en', '')}`),


### PR DESCRIPTION
Those two await statements are unnecessary in this case.

And I can't find any instruction from `pages/api/revalidate.ts` by your comments in https://github.com/zolplay-cn/website/blob/36680991f0f8ce17ea5bf37d58320dea43a67e95/.env.example#LL13C5-L13C5 , am i missing something ?