### PR TITLE
fix: try to fix sticky sidebar layout position calcuation

### DIFF
--- a/app/Sidebar.tsx
+++ b/app/Sidebar.tsx
@@ -60,7 +60,7 @@ export function Sidebar({ className }: { className?: string }) {
     <aside
       className={clsxm('md:mx-0 md:w-44 md:flex-shrink-0 md:px-0', className)}
     >
-      <div className="md:sticky md:top-12 md:pr-4">
+      <motion.div className="md:sticky md:top-12 md:pr-4" layout layoutRoot>
         <Link
           href="/"
           aria-label={t('Title')}
@@ -129,7 +129,7 @@ export function Sidebar({ className }: { className?: string }) {
           <LocaleSelector />
           <Clock />
         </motion.div>
-      </div>
+      </motion.div>
     </aside>
   )
 }


### PR DESCRIPTION
![CleanShot 2023-07-07 at 5 53 37](https://github.com/zolplay-cn/website/assets/41265413/b170f139-f2e7-4e76-b8ab-79cbfddcbe30)


Refer: https://www.framer.com/motion/layout-animations/###sticky-element-isnt-animating-as-expected