### PR TITLE
feat: posthog reverse proxy

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,42 @@ const nextConfig: NextConfig = {
       },
     ],
   },
+  // PostHog proxy configuration: Rewrites analytics requests through our domain to bypass ad blockers
+  // Handles both root paths (/ingest/*) and localized paths (/:locale/ingest/*)
+  // Referenced from https://posthog.com/docs/advanced/proxy/nextjs
+  async rewrites() {
+    return [
+      // Standard paths - no locale prefix
+      {
+        source: "/ingest/static/:path*",
+        destination: "https://us-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/ingest/:path*",
+        destination: "https://us.i.posthog.com/:path*",
+      },
+      { 
+        source: "/ingest/decide",
+        destination: "https://us.i.posthog.com/decide",
+      },
+      
+      // Localized paths with language prefix
+      {
+        source: "/:locale/ingest/static/:path*",
+        destination: "https://us-assets.i.posthog.com/static/:path*",
+      },
+      {
+        source: "/:locale/ingest/:path*",
+        destination: "https://us.i.posthog.com/:path*",
+      },
+      { 
+        source: "/:locale/ingest/decide",
+        destination: "https://us.i.posthog.com/decide",
+      },
+    ];
+  },
+  // This is required to support PostHog trailing slash API requests
+  skipTrailingSlashRedirect: true, 
 }
 
 const withNextIntl = createNextIntlPlugin('./modules/i18n/request.ts')


### PR DESCRIPTION
## Configure PostHog proxy to bypass ad blockers

This PR implements a proxy configuration for PostHog analytics to prevent ad blockers from intercepting tracking requests.

### Required Environment Variable

Please set the following environment variable in both beta and production environments:

`NEXT_PUBLIC_POSTHOG_HOST="/ingest"`